### PR TITLE
Amendment of documentation, additional operations

### DIFF
--- a/queue.lisp
+++ b/queue.lisp
@@ -25,33 +25,41 @@
    ;; push/pop elements on/off the queue
    #:queue-push
    #:queue-pop
-   #:queue-list))
+   #:queue-list
+   #:queue-peek
+   #:queue-clear
+   #:queue-size
+   #:queue-empty-p))
 
 (in-package :queue)
 
 ;;; ----------------------------------------------------
 
 (defstruct (queue (:constructor %make-queue (xs &aux (ys (last xs)))))
+  "Implements a list-based queue, capable of efficient insertions at the
+   tail."
   (head xs :read-only t)
   (tail ys :read-only t))
 
 ;;; ----------------------------------------------------
 
 (defun make-queue (&key initial-contents)
-  "Create a new queue."
+  "Create a new queue, optionally prepopulated with the elements of a
+   specified list."
   (%make-queue (cons nil initial-contents)))
 
 ;;; ----------------------------------------------------
 
 (defmethod print-object ((q queue) stream)
-  "Output a deque to a stream."
+  "Output the queue to a stream."
   (print-unreadable-object (q stream :type t)
     (format stream "~:[EMPTY~;~:*~a~]" (rest (queue-head q)))))
 
 ;;; ----------------------------------------------------
 
 (defun queue-push (x q)
-  "Push a value onto the tail of the queue."
+  "Push a value onto the tail of the queue and return the inserted
+   object."
   (with-slots (tail)
       q
     (car (setf tail (cdr (rplacd tail (list x)))))))
@@ -59,7 +67,7 @@
 ;;; ----------------------------------------------------
 
 (defun queue-pop (q)
-  "Pop a value off a queue, return the value and success flag."
+  "Pop a value off the queue, return the value and a success flag."
   (with-slots (head)
       q
     (when (rest head)
@@ -70,3 +78,33 @@
 (defun queue-list (q)
   "Return the list of elements in the queue; does not alter the queue."
   (rest (queue-head q)))
+
+;;; ----------------------------------------------------
+
+(defun queue-peek (q)
+  "Return without removing the first element of the queue in conjunction
+   with a success flag."
+  (when (rest (queue-head q))
+    (values (car (rest (queue-head q))) t)))
+
+;;; ----------------------------------------------------
+
+(defun queue-clear (q)
+  "Remove all elements of the queue and return the modified queue."
+  (with-slots (head tail)
+      q
+    (setf head (cons nil nil))
+    (setf tail (last head)))
+  q)
+
+;;; ----------------------------------------------------
+
+(defun queue-size (q)
+  "Return the number of elements in the queue."
+  (length (rest (queue-head q))))
+
+;;; ----------------------------------------------------
+
+(defun queue-empty-p (q)
+  "Check whether the queue is empty."
+  (null (rest (queue-head q))))


### PR DESCRIPTION
- Amended the documentation of the “print-object” function.
- Added a documentation string for the “queue” structure.
- Added four adscititious convenience operations: “queue-peek”, “queue-clear”, “queue-size”, and “queek-empty-p”. Their inclusion, albeit capable of derivation from the extant “queue-list” facility, offers an augmented encapsulation.